### PR TITLE
Switch historical sandbox to Python and isolate backend endpoint

### DIFF
--- a/backend/app/history_sandbox.py
+++ b/backend/app/history_sandbox.py
@@ -1,0 +1,84 @@
+import contextlib
+import io
+from typing import Any, Dict
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class HistoryPythonSandboxRequest(BaseModel):
+    code: str
+    appointments: list[dict[str, Any]]
+    clients: list[dict[str, Any]]
+    clinicians: list[dict[str, Any]]
+    constraints: dict[str, Any]
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    return str(value)
+
+
+@router.post("/sandbox/history/python")
+def run_history_python_sandbox(payload: HistoryPythonSandboxRequest) -> Dict[str, Any]:
+    """
+    NOTE: The user's code should assign its final output to a variable named `result`.
+    """
+    safe_builtins = {
+        "__import__": __import__,
+        "len": len,
+        "sum": sum,
+        "min": min,
+        "max": max,
+        "sorted": sorted,
+        "enumerate": enumerate,
+        "range": range,
+        "any": any,
+        "all": all,
+        "abs": abs,
+        "round": round,
+        "set": set,
+        "list": list,
+        "dict": dict,
+        "tuple": tuple,
+        "str": str,
+        "int": int,
+        "float": float,
+        "bool": bool,
+        "Exception": Exception,
+        "print": print,
+    }
+
+    globals_dict = {"__builtins__": safe_builtins}
+    locals_dict = {
+        "appointments": payload.appointments,
+        "clients": payload.clients,
+        "clinicians": payload.clinicians,
+        "CONSTRAINTS": payload.constraints,
+    }
+
+    stdout_buffer = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(stdout_buffer):
+            exec(payload.code, globals_dict, locals_dict)
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+    if "result" not in locals_dict:
+        return {
+            "ok": False,
+            "error": "Your Python code must assign the final output to a variable named `result`.",
+        }
+
+    return {
+        "ok": True,
+        "value": _json_safe(locals_dict["result"]),
+        "stdout": stdout_buffer.getvalue(),
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,11 @@ import numpy as np
 from sklearn.preprocessing import StandardScaler
 from sklearn.cluster import KMeans
 
+try:
+    from .history_sandbox import router as history_sandbox_router
+except ImportError:
+    from history_sandbox import router as history_sandbox_router
+
 app = FastAPI(title="Clinic Analytics API")
 
 # Vite dev server is typically :5173, while other local apps may run on :3000.
@@ -31,6 +36,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.include_router(history_sandbox_router)
 
 # ============================================================
 # INPUT FILE DISCOVERY


### PR DESCRIPTION
- Replace JavaScript execution in Historical Data playground with backend-powered Python execution.

- Add dedicated backend sandbox module (history_sandbox.py) and register it via router in main.py.

- Update starter snippets and UI copy for Python data analysis workflow.

Closes #3